### PR TITLE
chore(package.json): update typings field

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+declare const observableSymbol: symbol;
+export = observableSymbol;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "index.js",
     "ponyfill.js",
     "readme.md",
-    "license"
+    "license",
+    "index.d.ts"
   ],
   "keywords": [
     "symbol",


### PR DESCRIPTION
This PR updates `package.json` to point type definition `index.d.ts`, allows TypeScript code can import and assign it if necessary like

``` js
import * as xxx from 'symbol-observable'

const $$observable = xxx;
```
