### PR TITLE
fix(index.js): use typeof to check for global or window definitions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
 /* global window */
 'use strict';
 
-module.exports = require('./ponyfill')(global || window || this);
+var root = this;
+if (typeof global !== 'undefined') {
+	root = global;
+} else if (typeof window !== 'undefined') {
+	root = window;
+}
+module.exports = require('./ponyfill')(root);


### PR DESCRIPTION
When running the package in a browser I get the following error:

```
ReferenceError: global is not defined
```

This pull request changes the code to use `typeof` to check and see if the global or window variables are defined to prevent this error from occurring.
