### PR TITLE
fix(types): use default syntax for typedef

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
 declare const observableSymbol: symbol;
-export = observableSymbol;
+export default observableSymbol;


### PR DESCRIPTION
this will enable projects consuming symbol-observable from TS (eg, RxJS) to use

``` typescript
import $$observable from 'symbol-observable'
```

rather than

``` typescript
import * as $$observable from 'symbol-observable'
```

This might? require downstream changes on RxJS but its more correct methinks.
