### PR TITLE
Fix typescript (continuation of PR 11 and 12)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["es2015"],
-  "plugins": ["add-module-exports"],
+  "presets": ["es2015"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib
+ts-test/test.js

--- a/es/index.js
+++ b/es/index.js
@@ -1,11 +1,14 @@
 /* global window */
 import ponyfill from './ponyfill';
 
-let root = this;
+var root = this;
 if (typeof global !== 'undefined') {
 	root = global;
 } else if (typeof window !== 'undefined') {
 	root = window;
 }
 
-export default ponyfill(root);
+var result = ponyfill(root);
+// being explicit
+result['default'] = result;
+export default result;

--- a/es/index.js
+++ b/es/index.js
@@ -9,6 +9,4 @@ if (typeof global !== 'undefined') {
 }
 
 var result = ponyfill(root);
-// being explicit
-result['default'] = result;
 export default result;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
 declare const observableSymbol: symbol;
-export = observableSymbol;
+export default observableSymbol;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
+    "test": "mocha && tsc ./ts-test/test.ts && node ./ts-test/test.js"
     "build": "babel es --out-dir lib",
     "test": "npm run build && mocha",
     "prepublish": "npm test"
@@ -39,6 +40,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.9.0",
     "chai": "^3.5.0",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "typescript": "^1.8.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "mocha && tsc ./ts-test/test.ts && node ./ts-test/test.js"
+    "test": "npm run build && mocha && tsc ./ts-test/test.ts && node ./ts-test/test.js",
     "build": "babel es --out-dir lib",
-    "test": "npm run build && mocha",
     "prepublish": "npm test"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   ],
   "devDependencies": {
     "babel-cli": "^6.9.0",
-    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.9.0",
     "chai": "^3.5.0",
     "mocha": "^2.4.5",

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 /* global describe, it */
 var expect = require('chai').expect;
-var $$observable = require('../');
+var $$observable = require('../').default;
 
 describe('integration test', function () {
 	if (typeof Symbol === 'function') {

--- a/test/ponyfill.js
+++ b/test/ponyfill.js
@@ -1,6 +1,6 @@
 /* global describe, it */
 var expect = require('chai').expect;
-var ponyfill = require('../lib/ponyfill');
+var ponyfill = require('../lib/ponyfill').default;
 
 describe('ponyfill unit tests', function () {
   describe('when Symbol does NOT exist as a function', function () {

--- a/ts-test/test.ts
+++ b/ts-test/test.ts
@@ -1,9 +1,10 @@
 import $$symbolObservable from '../';
 
-console.log('***********************');
-console.log('RUNNING TYPESCRIPT TEST');
-console.log('***********************');
+console.log('RUNNING TYPESCRIPT TEST...');
 
 if (typeof $$symbolObservable !== 'symbol' && <any>$$symbolObservable !== '@@observable') {
+  console.log('FAIL');
   throw new Error('Sorry, $symbolObservable is ' + JSON.stringify($$symbolObservable));
 }
+
+console.log('PASS');

--- a/ts-test/test.ts
+++ b/ts-test/test.ts
@@ -1,0 +1,9 @@
+import $$symbolObservable from '../';
+
+console.log('***********************');
+console.log('RUNNING TYPESCRIPT TEST');
+console.log('***********************');
+
+if (typeof $$symbolObservable !== 'symbol' && <any>$$symbolObservable !== '@@observable') {
+  throw new Error('Sorry, $symbolObservable is ' + JSON.stringify($$symbolObservable));
+}


### PR DESCRIPTION
This embodies all of the changes discussed in PR 11 and 12.

There is a BREAKING CHANGE here however.. CJS users will have to `require('symbol-observable').default`.

cc/ @gaearon @robwormald
