### PR TITLE
Compile to UMD and add AMD main.js

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
+  "plugins": ["transform-es2015-modules-umd"],
   "presets": ["es2015"]
 }

--- a/main.js
+++ b/main.js
@@ -1,0 +1,3 @@
+define([ './lib/index' ], function (symbolObservable) {
+	return symbolObservable;
+});

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "devDependencies": {
     "babel-cli": "^6.9.0",
-    "babel-plugin-transform-es2015-modules-umd": "^6.8.0",
+    "babel-plugin-transform-es2015-modules-umd": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-es3": "^1.0.0",
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "files": [
     "index.js",
+    "main.js",
     "ponyfill.js",
     "index.d.ts",
     "es/index.js",
@@ -37,6 +38,7 @@
   ],
   "devDependencies": {
     "babel-cli": "^6.9.0",
+    "babel-plugin-transform-es2015-modules-umd": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "chai": "^3.5.0",
     "mocha": "^2.4.5",

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,8 @@ $ npm install --save symbol-observable
 
 ## Usage
 
+With a CommonJS loader:
+
 ```js
 const symbolObservable = require('symbol-observable');
 
@@ -19,6 +21,23 @@ console.log(symbolObservable);
 //=> Symbol(observable)
 ```
 
+With an ES2015 module loader:
+
+```js
+import symbolObservable from 'symbol-observable';
+
+console.log(symbolObservable);
+//=> Symbol(observable)
+```
+
+With an AMD module loader:
+
+```js
+require([ 'symbol-observable' ], function (symbolObservable) {
+	console.log(symbolObservable);
+	//=> Symbol(observable)
+});
+```
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ $ npm install --save symbol-observable
 With a CommonJS loader:
 
 ```js
-const symbolObservable = require('symbol-observable');
+const symbolObservable = require('symbol-observable').default;
 
 console.log(symbolObservable);
 //=> Symbol(observable)
@@ -34,7 +34,7 @@ With an AMD module loader:
 
 ```js
 require([ 'symbol-observable' ], function (symbolObservable) {
-	console.log(symbolObservable);
+	console.log(symbolObservable.default);
 	//=> Symbol(observable)
 });
 ```


### PR DESCRIPTION
This PR resolves ReactiveX/rxjs#1664.
- Adds Babel Plugin [babel-plugin-transform-es2015-modules-umd](https://babeljs.io/docs/plugins/transform-es2015-modules-umd/) to compile the modules to a format that can be loaded by both CommonJS and AMD modules.
- Adjusts the `.babelrc` to utilise the plug-in
- Adds a `main.js` which is an AMD module that replicates the functionality of `index.js`
- Modifies the `package.json` to add both Babel plugin as a development dependency as well add the `main.js` to the `files`
  - Note that `files` in `package.json` refers to `ponyfill.js` which appears to not be part of the package, though `lib/ponyfill.js` appears to be present and referred to as well.  I did not address this.
- Modified the `readme.md` to reflect usage.
  - Note, since the `lib/index.js` has a ES2015 default export, the example shown in the readme was incorrect.  I have corrected this.

I tested this within a TypeScript project that uses the [dojo/loader](https://github.com/dojo/loader) which properly loaded the package, that was located in the `node_modules` of the project with the following AMD loader config:

``` js
require.config({
    packages: [
        { name: 'symbol-observable', location: 'node_modules/symbol-observable' }
    ]
});
```

The loader properly loaded the `symbol-obersevable/main.js` which in turn loaded the `lib/index.js` and then the `lib/ponyfill.js`.
