### PR TITLE
Support for mozilla addons

### DIFF
--- a/es/index.js
+++ b/es/index.js
@@ -1,11 +1,16 @@
 /* global window */
 import ponyfill from './ponyfill';
 
-var root = this;
-if (typeof global !== 'undefined') {
-	root = global;
+var root = module;
+
+if (typeof self !== 'undefined') {
+  root = self;
 } else if (typeof window !== 'undefined') {
-	root = window;
+  root = window;
+} else if (typeof global !== 'undefined') {
+  root = global;
+} else {
+  root = Function('return this')();
 }
 
 var result = ponyfill(root);


### PR DESCRIPTION
Currently _symbol-observable_ doesn't work for mozilla addons (at least jetpack-based ones). It cannot find valid global object, because `root = this` is transpiled to `root = undefined` (es6 modules causes this), and there is neither `global` nor `window` object inside addon environment. I've used implementation of [polyfill for _global_ proposal](https://github.com/ljharb/System.global) to fix this issue. This fix should also enable support for _web workers_ and _node-webkit_.
