### PR TITLE
Fix global Symbol.observable typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,12 @@
 declare const observableSymbol: symbol;
 export default observableSymbol;
+
+declare global {
+  export interface SymbolConstructor {
+    readonly observable: symbol;
+  }
+}
+
+export interface Symbol {
+  readonly [Symbol.observable]: symbol;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,8 @@ declare global {
   export interface SymbolConstructor {
     readonly observable: symbol;
   }
+
+  export const Symbol: SymbolConstructor;
 }
 
 export interface Symbol {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "chai": "^3.5.0",
     "check-es3-syntax-cli": "^0.1.0",
     "mocha": "^2.4.5",
-    "typescript": "^1.8.10"
+    "typescript": "^2.1.4"
   }
 }


### PR DESCRIPTION
This is a continuation of #28. 

- updates TypeScript to 2.0+
- fixes global type definition for `Symbol.observable`