### PR TITLE
Fully qualified import for native esm browser support

### DIFF
--- a/es/index.js
+++ b/es/index.js
@@ -1,5 +1,5 @@
 /* global window */
-import ponyfill from './ponyfill';
+import ponyfill from './ponyfill.js';
 
 var root;
 


### PR DESCRIPTION
The typical bundlers (rollup et.al.) do not care, but browser do. Add '.js' so we can import this file directly from the browser.