### PR TITLE
Add module field for esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lib/index.js",
     "lib/ponyfill.js"
   ],
+  "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "typings": "index.d.ts",
   "keywords": [


### PR DESCRIPTION
`jsnext:main` field is deprecated in favor of `module` field which is supported with both `rollup` (`rollup-plugin-node-resolve`) and `webpack`.