### PR TITLE
feat(bundlers): Add module and main entries in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "lib/index.js",
     "lib/ponyfill.js"
   ],
+  "main": "lib/index.js",
+  "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "typings": "index.d.ts",
   "keywords": [


### PR DESCRIPTION
`jsnext:main` is somewhat deprecated and some might argue it should be completely replaced with `module`. Personally I don't care about extra field in `package.json` if it helps somebody, OTOH if we leave it hanging everywhere it will still be here with us for next few years and that is harmful for the ecosystem. Your choice  ¯\\_(ツ)_/¯

As to adding `main` - with the change I think we can remove `./index.js` safely, any objections? Personally I don't think this kind of "proxying" module do any good if we can use `main` to help the resolving algorithms.