### PR TITLE
Remove global.Symbol declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,8 +5,6 @@ declare global {
   export interface SymbolConstructor {
     readonly observable: symbol;
   }
-
-  export const Symbol: SymbolConstructor;
 }
 
 export interface Symbol {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "npm run build && mocha && tsc ./ts-test/test.ts && node ./ts-test/test.js && check-es3-syntax -p lib/ --kill",
+    "test": "npm run build && mocha && tsc && node ./ts-test/test.js && check-es3-syntax -p lib/ --kill",
     "build": "babel es --out-dir lib",
     "prepublish": "npm test"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "include": [
+    "./ts-test"
+  ],
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "lib": [
+      "dom",
+      "es5",
+      "scripthost",
+      "es2015.symbol"
+    ]
+  }
+}


### PR DESCRIPTION
Since there is no polyfill for `global.Symbol`, it should not be declared here. `Symbol` comes from Typescript's lib, node's declaration or other place as polyfill's typings

* `tsconfig.json` added so that `tsc` command is self sufficient
* `es2015.symbol` included to typescript's `lib`
* `Symbol` declaration removed

Fixes #34 