### PR TITLE
fix: Ponyfill should not tamper with globals

### DIFF
--- a/es/index.js
+++ b/es/index.js
@@ -16,4 +16,10 @@ if (typeof self !== 'undefined') {
 }
 
 var result = ponyfill(root);
+
+root.Symbol = root.Symbol || function Symbol(description) {
+  return '@@' + description;
+};
+root.Symbol.observable = result;
+
 export default result;

--- a/es/ponyfill.js
+++ b/es/ponyfill.js
@@ -1,17 +1,23 @@
-export default function symbolObservablePonyfill(root) {
-	var result;
-	var Symbol = root.Symbol;
 
+const observableSymbols = new WeakMap();
+
+export default function symbolObservablePonyfill(root) {
+	var result = observableSymbols.get(root);
+	if (result) {
+		return result;
+	}
+
+	var Symbol = root.Symbol;
 	if (typeof Symbol === 'function') {
 		if (Symbol.observable) {
 			result = Symbol.observable;
 		} else {
 			result = Symbol('observable');
-			Symbol.observable = result;
 		}
 	} else {
 		result = '@@observable';
 	}
 
+	observableSymbols.set(root, result);
 	return result;
 };

--- a/test/ponyfill.js
+++ b/test/ponyfill.js
@@ -23,7 +23,7 @@ describe('ponyfill unit tests', function () {
     });
 
     describe('and Symbol.observable does NOT exist', function () {
-      it('should use Symbol(), polyfill Symbol.observable and return it', function () {
+      it('should use Symbol()', function () {
         var Symbol = function (description) {
           return 'Symbol(' + description + ')';
         };
@@ -33,7 +33,6 @@ describe('ponyfill unit tests', function () {
 
         var result = ponyfill(root);
 
-        expect(Symbol.observable).to.equal('Symbol(observable)');
         expect(result).to.equal('Symbol(observable)');
       });
     });


### PR DESCRIPTION
@benlesh For your consideration,

Prior to this change, the ponyfill module would also polyfill Symbol.observable. With this change, the ponyfill can be used in environments with immutable primordials.

Please let me know if this change is acceptable, or if I can adjust it to be consistent with this project’s style.