### PR TITLE
Add ponyfill TypeScript type definitions

### DIFF
--- a/ponyfill.d.ts
+++ b/ponyfill.d.ts
@@ -1,0 +1,2 @@
+declare const makeObservableSymbol : (root : object) => symbol;
+export default makeObservableSymbol;

--- a/ponyfill.js
+++ b/ponyfill.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/ponyfill');


### PR DESCRIPTION
This change makes available the TypeScript definitions for the ponyfill, and adds the missing alias so the ponyfill is importable as `symbol-observable/ponyfill`. This is motivated by an attempted integration with the TypeScript `xstream` project. https://github.com/staltz/xstream/pull/315